### PR TITLE
fix UnexpectedContentType when charset parameter is present on content-type headers

### DIFF
--- a/scim2_client/client.py
+++ b/scim2_client/client.py
@@ -176,7 +176,7 @@ class SCIMClient:
         # https://datatracker.ietf.org/doc/html/rfc7644.html#section-8.1
 
         expected_response_content_types = ("application/scim+json", "application/json")
-        if response.headers.get("content-type") not in expected_response_content_types:
+        if response.headers.get("content-type").split(';').pop(0) not in expected_response_content_types:
             raise UnexpectedContentType(source=response)
 
         # In addition to returning an HTTP response code, implementers MUST return


### PR DESCRIPTION
For responses with charset defined, like `Content-type: application/json; charset=utf-8`, the expected_response_content_types check will fail, even with `application/json` being an expected type.

According to https://www.w3.org/Protocols/rfc1341/4_Content-Type.html, content type will follow the pattern:

```
Content-Type := type "/" subtype *[";" parameter]

type := "application" / "audio" / "image" / "message" / "multipart" / "text" / "video" / x-token

x-token := < The two characters "X-" followed, with no intervening white space, by any token >

subtype := token

parameter := attribute "=" value

attribute := token

value := token / quoted-string

token := 1*<any CHAR except SPACE, CTLs, or tspecials>

tspecials := "(" / ")" / "<" / ">" / "@" ; Must be in / "," / ";" / ":" / "" / <"> ; quoted-string, / "/" / "[" / "]" / "?" / "." ; to use within / "=" ; parameter values
```

This PR suggests separating the type/subtype from possible parameters (but i'm not sure if in the most pythonic way).