### PR TITLE
Support including charset in Content-Type

### DIFF
--- a/scim2_client/client.py
+++ b/scim2_client/client.py
@@ -176,7 +176,7 @@ class SCIMClient:
         # https://datatracker.ietf.org/doc/html/rfc7644.html#section-8.1
 
         expected_response_content_types = ("application/scim+json", "application/json")
-        if response.headers.get("content-type") not in expected_response_content_types:
+        if response.headers.get("content-type", '').split(';')[0] not in expected_response_content_types:
             raise UnexpectedContentType(source=response)
 
         # In addition to returning an HTTP response code, implementers MUST return


### PR DESCRIPTION
Content-Type not only includes the mime, but may include other information in it like Charset.

The server may response with a Content-Type set to `application/scim+json; charset=utf-8` for instance, it is still valid.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type